### PR TITLE
[#1078] Fix typo in package-restore-troubleshooting doc

### DIFF
--- a/docs/consume-packages/Package-restore-troubleshooting.md
+++ b/docs/consume-packages/Package-restore-troubleshooting.md
@@ -37,7 +37,7 @@ This project references NuGet package(s) that are missing on this computer.
 Use NuGet Package Restore to download them. The missing file is {name}.
 ```
 
-This error occurs you attempt to build a project that contains references to one or more NuGet packages, but those packages are not presently installed on the computer or in the project.
+This error occurs when you attempt to build a project that contains references to one or more NuGet packages, but those packages are not presently installed on the computer or in the project.
 
 - When using the PackageReference management format, the error means that the package is not installed in the *global-packages* folder as described on [Managing the global packages and cache folders](managing-the-global-packages-and-cache-folders.md).
 - When using `packages.config`, the error means that the package is not installed in the `packages` folder at the solution root.


### PR DESCRIPTION
**Description**:
This PR fixes a trivial typo in the Package-resource-troubleshooting documentation, making it easier to read for users. Issue referenced in [#1078](https://github.com/NuGet/docs.microsoft.com-nuget/issues/1078)